### PR TITLE
16 context team

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.yetanalytics/xapi-schema "0.1.4"
+(defproject com.yetanalytics/xapi-schema "0.1.5-SNAPSHOT"
   :description "Clojure(script) Schema for the Experience API v1.0.3"
   :url "https://github.com/yetanalytics/xapi-schema"
   :license {:name "Eclipse Public License"

--- a/spec/xapi_schema/schemata/json_spec.cljc
+++ b/spec/xapi_schema/schemata/json_spec.cljc
@@ -409,7 +409,17 @@
 (describe
  "Context"
  (it "can be empty"
-     (should-satisfy Context {})))
+     (should-satisfy Context {}))
+ (describe
+  "team"
+  (it "must be a group"
+      (should-satisfy+ Context
+                       {"team" {"mbox" "mailto:a@b.com"
+                                "objectType" "Group"}}
+                       :bad
+                       {"team" {"mbox" "mailto:a@b.com"}}
+                       {"team" {"mbox" "mailto:a@b.com"
+                                "objectType" "Agent"}}))))
 
 (describe
  "Attachment"

--- a/spec/xapi_schema/schemata/json_spec.cljc
+++ b/spec/xapi_schema/schemata/json_spec.cljc
@@ -303,28 +303,33 @@
   "Anonymous Groups"
   (it "must have a member property"
       (should-satisfy+ Group
-                       {"member" [{"mbox" "mailto:milt@yetanalytics.com"}]}
+                       {"member" [{"mbox" "mailto:milt@yetanalytics.com"}]
+                        "objectType" "Group"}
                        :bad
-                       {}
-                       {"member" []})))
+                       {"objectType" "Group"}
+                       {"member" []
+                        "objectType" "Group"})))
  (context
   "Identified Group"
   (it "must have one or no IFI"
       (should-satisfy+ Group
-                       {"mbox" "mailto:milt@yetanalytics.com"}
-                       :bad
-                       {}
                        {"mbox" "mailto:milt@yetanalytics.com"
-                        "openid" "https://some.site.com/foo"})))
+                        "objectType" "Group"}
+                       :bad
+                       {"objectType" "Group"}
+                       {"mbox" "mailto:milt@yetanalytics.com"
+                        "openid" "https://some.site.com/foo"
+                        "objectType" "Group"})))
  (context
   "objectType"
-  (it "must be Group if provided"
-      (key-should-satisfy+ Group
-                           {"mbox" "mailto:milt@yetanalytics.com"}
-                           "objectType"
-                           "Group"
-                           :bad
-                           "Agent"))))
+  (it "must be present and be Group"
+      (should-satisfy+ Group
+                       {"mbox" "mailto:somegroup@yetanalytics.com"
+                        "objectType" "Group"}
+                       :bad
+                       {"mbox" "mailto:so@yetanalytics.com"}
+                       {"mbox" "mailto:somegroup@yetanalytics.com"
+                        "objectType" "Agent"}))))
 
 (describe
  "Verb"

--- a/src/xapi_schema/schemata/json.cljc
+++ b/src/xapi_schema/schemata/json.cljc
@@ -213,7 +213,7 @@
   Group
   (s/named
    (s/both
-    {(s/optional-key "objectType") (s/both s/Str (s/eq "Group")) ;; Group
+    {(s/required-key "objectType") (s/both s/Str (s/eq "Group")) ;; Group
      (s/optional-key "name") s/Str
      (s/optional-key "mbox") MailToIRI
      (s/optional-key "mbox_sha1sum") Sha1Sum


### PR DESCRIPTION
Per issue #16, ensure that a statement context's team is a group! Additionally, require that groups carry the objectType "Group" across the board.