### PR TITLE
26 schema 101

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,14 +4,14 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/clojurescript "1.7.28"]
-                 [prismatic/schema "0.4.3"]
+                 [org.clojure/clojurescript "1.7.122"]
+                 [prismatic/schema "1.0.1"]
                  [cheshire "5.5.0"]
                  [org.clojure/core.match "0.3.0-alpha4"]
                  [com.taoensso/tower "3.1.0-beta3"]]
   :exclusions [[org.clojure/clojure]
                [org.clojure/clojurescript]]
-  :plugins [[lein-cljsbuild "1.0.6"]]
+  :plugins [[lein-cljsbuild "1.1.0"]]
   :profiles {:dev {:dependencies [[speclj "3.3.1"]]}}
 
   :cljsbuild {:builds [{:id "dev"

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.yetanalytics/xapi-schema "0.1.5"
+(defproject com.yetanalytics/xapi-schema "0.1.6-SNAPSHOT"
   :description "Clojure(script) Schema for the Experience API v1.0.3"
   :url "https://github.com/yetanalytics/xapi-schema"
   :license {:name "Eclipse Public License"

--- a/src/xapi_schema/schemata/util.cljc
+++ b/src/xapi_schema/schemata/util.cljc
@@ -84,11 +84,13 @@
          [([(what :guard keyword?) value] :seq)] (str (t ltag what) ": " value)
          [(['sequential? value] :seq)] (str (t ltag :sequential) ": " value)
          [(['map? value] :seq)] (str (t ltag :map) ": " value)
-         [(['integer? value] :seq)] (str (t ltag :integer) ": " value)
+         [#?(:clj
+             (['integer? value] :seq)
+             :cljs
+             (['cljs$core$integer? value] :seq))] (str (t ltag :integer) ": " value)
 
-         ;; catch cljs string schema, as it is just string?
          #?@(:cljs
-             [[([(what :guard (partial = string?)) value] :seq)]
+             [[(['cljs$core$string? value] :seq)]
               (str (t ltag :string) ": " value)])
 
          [(['instance? klass value] :seq)]


### PR DESCRIPTION
Updates schema to 1.0.1, cljs to 1.7.122.
Fixes #26 
Fixed error parsing for new cljs integer and string errors.

`schema.core/both` is now deprecated, and we use it a lot. The suggestion is to use `schema.core/conditional` in a nested fashion as described [here](https://github.com/Prismatic/schema/issues/269) but I'm not wild about it. They mention there might be a better facility to replace it soon...