### PR TITLE
Remove both schemata

### DIFF
--- a/spec/xapi_schema/schemata/predicates_spec.cljc
+++ b/spec/xapi_schema/schemata/predicates_spec.cljc
@@ -1,7 +1,16 @@
 (ns xapi-schema.schemata.predicates-spec
-  #?@(:cljs [(:require-macros [speclj.core :refer [describe context with it should should= should-not run-specs pending]])
+  #?@(:cljs [(:require-macros [speclj.core :refer [describe
+                                                   context
+                                                   with
+                                                   it
+                                                   should
+                                                   should=
+                                                   should-not
+                                                   run-specs
+                                                   pending]])
              (:require [speclj.core]
-                       [xapi-schema.schemata.predicates :refer [regex-pred
+                       [xapi-schema.schemata.predicates :refer [ifi-count
+                                                                no-ifi?
                                                                 re-pred
                                                                 unique-ids?
                                                                 valid-component-keys?

--- a/spec/xapi_schema/schemata/predicates_spec.cljc
+++ b/spec/xapi_schema/schemata/predicates_spec.cljc
@@ -190,5 +190,7 @@
  "Utils"
  (describe
   "re-pred"
-  (xit "takes a regex, and returns a simple predicate fn"
-      )))
+  (with re #"^[A-Z]$")
+  (it "takes a regex, and returns a simple predicate fn"
+      (should ((re-pred @re) "A"))
+      (should-not ((re-pred @re) "a")))))

--- a/spec/xapi_schema/schemata/predicates_spec.cljc
+++ b/spec/xapi_schema/schemata/predicates_spec.cljc
@@ -1,25 +1,21 @@
 (ns xapi-schema.schemata.predicates-spec
   #?@(:cljs [(:require-macros [speclj.core :refer [describe context with it should should= should-not run-specs pending]])
              (:require [speclj.core]
-                       [xapi-schema.schemata.predicates :refer [ifi-count
-                                                                no-multi-ifi?
-                                                                ifi-present?
-                                                                no-ifi?
+                       [xapi-schema.schemata.predicates :refer [regex-pred
+                                                                re-pred
                                                                 unique-ids?
                                                                 valid-component-keys?
+                                                                no-multi-ifi?
+                                                                ifi-present?
+                                                                has-members?
+                                                                score-raw-lte-max
+                                                                score-raw-gte-min
+                                                                score-min-lt-max
+                                                                two-members?
                                                                 valid-revision?
                                                                 valid-platform?
-                                                                valid-context-pred
-                                                                regex-pred
-                                                                no-multi-ifi-pred
-                                                                one-ifi-required-pred
-                                                                void-statement-ref-pred
-                                                                AgentValidations
-                                                                GroupValidations
-                                                                InteractionComponentsValidations
-                                                                DefinitionValidations
-                                                                ScoreValidations
-                                                                StatementValidations]]
+                                                                valid-void?
+                                                                ]]
                        [schema.core :as s
                         :include-macros true]
                        [xapi-schema.support.schema :refer [should-satisfy
@@ -65,6 +61,21 @@
   (it "returns true if there are no ifi keys"
       (should (no-ifi? {}))
       (should-not (no-ifi? {"mbox" "mailto:milt@yetanalytics.com"})))))
+
+(describe
+ "group predicates"
+ (describe
+  "has-members?"
+  (it "is truthy if the group object has members"
+      (should (has-members? {"member" [{}]}))
+      (should-not (has-members? {}))
+      (should-not (has-members? {"member" nil}))))
+ (describe
+  "two members?"
+  (it "is truthy if the members vector has exactly two members"
+      (should (two-members? [{}{}]))
+      (should-not (two-members? [{}])))))
+
 
 (describe
  "interaction component predicates"
@@ -126,158 +137,49 @@
        (should (valid-platform? {}))))))
 
 (describe
- "predicate schemata, builders"
+ "Score Predicates"
  (describe
-  "valid-context-pred"
-  (context
-   "with valid structure for revision and/or platform"
-   (it "is satisfied"
-       (should-satisfy
-        valid-context-pred {"object" {"objectType" "Activity"}
-                            "context" {"revision" "whatever"
-                                       "platform" "whatever"}})))
-  (context
-   "with invalid structure for revision and/or plaform"
-   (it "is not satisfied"
-       (should-not-satisfy
-        valid-context-pred {"object" {"objectType" "StatementRef"}
-                            "context" {"revision" "whatever"
-                                       "platform" "whatever"}}))))
+  "score-raw-lte-max"
+  (it "is truthy if the raw score is less than or equal to max"
+      (should (score-raw-lte-max
+               {"raw" 5
+                "max" 10}))
+      (should-not (score-raw-lte-max
+                   {"raw" 10
+                    "max" 5}))))
  (describe
-  "regex-pred"
-  (context
-   "given a regex and a message"
-   (with pred (regex-pred #"[A-Z]" "A capital letter"))
-   (it "creates a regex predicate"
-       (should-satisfy+ @pred "A" :bad "a"))))
+  "score-raw-gte-min"
+  (it "is truthy if the raw score is greater than or equal to min"
+      (should (score-raw-gte-min
+               {"raw" 5
+                "min" 0}))
+      (should-not (score-raw-gte-min
+                   {"raw" 1
+                    "min" 5}))))
  (describe
-  "no-multi-ifi-pred"
-  (it "checks that there are not multiple IFIs"
-      (should-satisfy+
-       no-multi-ifi-pred
-       {}
-       {"mbox" "mailto:milt@yetanalytics.com"}
-       :bad
-       {"foo" "bar"
-        "mbox" "mailto:milt@yetanalytics.com"
-        "account" {"homePage" "http://www.foo.com"
-                   "name" "foobar"}})))
- (describe
-  "one-ifi-required-pred"
-  (it "checks that there is one and only one IFI"
-      (should-satisfy+
-       one-ifi-required-pred
-       {"mbox" "mailto:milt@yetanalytics.com"}
-       :bad
-       {"foo" "bar"
-        "mbox" "mailto:milt@yetanalytics.com"
-        "account" {"homePage" "http://www.foo.com"
-                   "name" "foobar"}}
-       {})))
- (describe
-  "void-statement-ref-pred"
-  (it "checks that voiding statements have an object with the type StatementRef"
-      (should-satisfy+
-       void-statement-ref-pred
-       {"verb" {"id" "http://adlnet.gov/expapi/verbs/voided"}
-        "object" {"objectType" "StatementRef"}}
-       :bad
-       {"verb" {"id" "http://adlnet.gov/expapi/verbs/voided"}
-        "object" {"id" "http://example.com/some/ambiguous/id"}}))))
+  "score-min-lt-max"
+  (it "is truthy if the min score is less than max"
+      (should (score-min-lt-max
+               {"min" 5
+                "max" 10}))
+      (should-not (score-min-lt-max
+                   {"min" 10
+                    "max" 5})))))
 
 (describe
- "validation predicate schemata"
+ "Statement Predicates"
  (describe
-  "AgentValidations"
-  (it "verifies that the agent has one and only one IFI"
-      (should-satisfy+
-       AgentValidations
-       {"mbox" "mailto:milt@yetanalytics.com"}
-       :bad
-       {"name" "Milt"}
-       {"foo" "bar"
-        "mbox" "mailto:milt@yetanalytics.com"
-        "account" {"homePage" "http://www.foo.com"
-                   "name" "foobar"}})))
+  "valid-void?"
+  (it "if the statement verb is void it checks for a statement ref object, otherwise true"
+      (should (valid-void? {"verb" {"id" "http://adlnet.gov/expapi/verbs/voided"}
+                           "object" {"objectType" "StatementRef"}}))
+      (should (valid-void? {}))
+      (should-not (valid-void? {"verb" {"id" "http://adlnet.gov/expapi/verbs/voided"}
+                               "object" {"objectType" "Activity"}})))))
+
+(describe
+ "Utils"
  (describe
-  "GroupValidations"
-  (context
-   "Identified Group"
-   (it "checks to make sure there is only one IFI"
-       (should-satisfy+
-        GroupValidations
-        {"mbox" "mailt:devteam@yetanalytics.com"}
-        :bad
-        {"mbox" "mailt:devteam@yetanalytics.com"
-         "openid" "http://foo.bar"})))
-  (context
-   "Anonymous Group"
-   (it "ensures the group has a member key"
-       (should-satisfy+
-        GroupValidations
-        {"member" []}
-        :bad
-        {"name" "some group"}))))
- (describe
-  "InteractionComponentsValidations"
-  (it "ensures that interaction components have unique ids"
-      (should-satisfy+
-       InteractionComponentsValidations
-       [{"id" "1"} {"id" "2"}]
-       :bad
-       [{"id" "1"} {"id" "1"}])))
- (describe
-  "DefinitionValidations"
-  (it "ensures that interaction component list keys are valid"
-      (should-satisfy+
-       DefinitionValidations
-       {"interactionType" "performance"
-        "steps" "foo"}
-       :bad
-       {"interactionType" "choice"
-        "steps" "foo"})))
- (describe
-  "ScoreValidations"
-  (context
-   "with a valid score"
-   (it "is satisfied"
-       (should-satisfy
-        ScoreValidations
-        {"max" 10
-         "min" 1
-         "raw" 5})))
-  (context
-   "with an invalid score"
-   (it "returns an error"
-       (should-satisfy+
-        ScoreValidations
-        {"max" 10
-         "min" 1
-         "raw" 5}
-        :bad
-        {"raw" 10 ;; raw higher than max
-         "max" 1}
-        {"min" 5 ;; raw lower than min
-         "raw" 1}
-        {"min" 10
-         "max" 1}))))
- (describe
-  "StatementValidations"
-  (it "validates statement context (platform and registration) structure"
-      (should-satisfy+
-       StatementValidations
-       {"object" {"objectType" "Activity"}
-        "context" {"registration" "whatever"
-                   "platform" "whatever"}}
-       :bad
-       {"object" {"objectType" "Agent"}
-        "context" {"registration" "whatever"
-                   "platform" "whatever"}}))
-  (it "validates the objectType of voiding statements"
-      (should-satisfy+
-       StatementValidations
-       {"verb" {"id" "http://adlnet.gov/expapi/verbs/voided"}
-        "object" {"objectType" "StatementRef"}}
-       :bad
-       {"verb" {"id" "http://adlnet.gov/expapi/verbs/voided"}
-        "object" {"id" "http://example.com/some/ambiguous/id"}}))))
+  "re-pred"
+  (xit "takes a regex, and returns a simple predicate fn"
+      )))

--- a/spec/xapi_schema/schemata/util_spec.cljc
+++ b/spec/xapi_schema/schemata/util_spec.cljc
@@ -239,19 +239,38 @@
                    "enum" "Not in #{\"foo\" \"bar\" \"baz\"}: quxx"
                    "one" ["Not present: at least one string"]}
                   (errors->data @err))))
-   (context "given some xapi validation cases"
-            (with bad-xapi (errors->data
-                            (s/check json/Statement
-                                     (assoc d/long-statement
-                                            "actor"
-                                            {"mbox" "mailto:milt@yetanalytics.com"
-                                             "objectType" "NotAnAgent"}))))
-             (it "parses an agent objectType error"
-                 (should-not-throw
-                  @bad-xapi))
-             (it "coerces the errors to strings"
-                 (should= {"actor" {"objectType" "Not Agent: NotAnAgent"}}
-                          @bad-xapi))))
+   (context
+    "given some xapi validation cases"
+    (context
+     "bad agent type"
+     (with bad-agent-type
+           (errors->data
+            (s/check json/Statement
+                     (assoc d/long-statement
+                            "actor"
+                            {"mbox" "mailto:milt@yetanalytics.com"
+                             "objectType" "NotAnAgent"}))))
+     (it "parses an agent objectType error"
+         (should-not-throw
+          @bad-agent-type))
+     (it "coerces the errors to strings"
+         (should= {"actor" {"objectType" "Not Agent: NotAnAgent"}}
+                  @bad-agent-type)))
+
+    (context
+     "Anon group with no members"
+     (with bad-anon-group
+           (errors->data
+            (s/check json/Statement
+                     (assoc d/long-statement
+                            "actor"
+                            {"objectType" "Group"
+                             "member" []}))))
+     (it "returns a localized error"
+         (should= {"actor" {"member" ["Not present: at least one Agent"]}}
+                  @bad-anon-group)))
+
+    ))
   (describe
    "errors->paths"
    (it "returns a map"

--- a/src/xapi_schema/schemata/i18n.cljc
+++ b/src/xapi_schema/schemata/i18n.cljc
@@ -11,4 +11,12 @@
                                         ;:dev-mode? true ; Set to true for auto dictionary reloading
    })
 
-(def t (make-t tower-config))
+(def t* (make-t tower-config))
+
+(defn t
+  "Return a localized string for key, or return the stringed key if not found"
+  [ltag k]
+  (let [localized (t* ltag k)]
+    (if-not (= localized "")
+      localized
+      (str k))))

--- a/src/xapi_schema/schemata/json.cljc
+++ b/src/xapi_schema/schemata/json.cljc
@@ -1,7 +1,6 @@
 (ns xapi-schema.schemata.json
   (:require
-   [xapi-schema.schemata.predicates :refer [regex-pred
-                                            re-pred
+   [xapi-schema.schemata.predicates :refer [re-pred
                                             unique-ids?
                                             valid-component-keys?
                                             no-multi-ifi?
@@ -13,13 +12,7 @@
                                             two-members?
                                             valid-revision?
                                             valid-platform?
-                                            valid-void?
-                                            InteractionComponentsValidations
-                                            DefinitionValidations
-                                            AgentValidations
-                                            GroupValidations
-                                            ScoreValidations
-                                            StatementValidations]]
+                                            valid-void?]]
    [xapi-schema.schemata.regex :refer [LanguageTagRegEx
                                        OpenIdRegEx
                                        AbsoluteIRIRegEx

--- a/src/xapi_schema/schemata/json.cljc
+++ b/src/xapi_schema/schemata/json.cljc
@@ -164,17 +164,16 @@
      (s/optional-key "description") LanguageMap
      (s/optional-key "correctResponsesPattern") [s/Str]
      (s/optional-key "interactionType")
-     (s/both s/Str
-             (s/enum "true-false"
-                     "choice"
-                     "fill-in"
-                     "long-fill-in"
-                     "matching"
-                     "performance"
-                     "sequencing"
-                     "likert"
-                     "numeric"
-                     "other"))
+     (s/enum "true-false"
+             "choice"
+             "fill-in"
+             "long-fill-in"
+             "matching"
+             "performance"
+             "sequencing"
+             "likert"
+             "numeric"
+             "other")
      (s/optional-key "type") IRI
      (s/optional-key "moreInfo") IRL
      (s/optional-key "choices") InteractionComponents

--- a/src/xapi_schema/schemata/predicates.cljc
+++ b/src/xapi_schema/schemata/predicates.cljc
@@ -35,6 +35,17 @@
   (= (ifi-count x)
      0))
 
+;; anon group
+
+(defn has-members?
+  [{:strs [member]}]
+  (seq member))
+
+;; three-legged-oauth group
+
+(defn two-members? [m]
+  (= 2 (count m)))
+
 ;; interaction component predicates
 
 (defn unique-ids?
@@ -98,11 +109,45 @@
       true
       (not platform-present?))))
 
+;; Score pred fns
+
+(defn score-raw-lte-max
+  [x]
+  (let [{:strs [raw max]} x]
+    (if (and raw max)
+      (<= raw max)
+      true)))
+
+(defn score-raw-gte-min
+  [x]
+  (let [{:strs [raw min]} x]
+    (if (and raw min)
+      (>= raw min)
+      true)))
+
+(defn score-min-lt-max
+  [x]
+  (let [{:strs [min max]} x]
+    (if (and min max)
+      (< min max)
+      true)))
+
+;; statement predicate fns
+(defn valid-void? [{:strs [verb object]}]
+  (if (= (get verb "id") "http://adlnet.gov/expapi/verbs/voided")
+    (= (get object "objectType") "StatementRef")
+    true))
+
 ;; Predicate schemata, builders
 
 (def valid-context-pred
   (s/both (s/pred valid-revision? :predicates/revision-not-allowed)
           (s/pred valid-platform? :predicates/platform-not-allowed)))
+
+(defn re-pred
+  [re]
+  #(not
+    (nil? (re-matches re %))))
 
 (defn regex-pred
   [regex message]
@@ -126,21 +171,26 @@
 
 ;; validation predicate schemata
 
+
+;; TODO: remove
 (def AgentValidations
   one-ifi-required-pred)
 
+;; TODO: remove
 (def GroupValidations
   (s/conditional ifi-present? no-multi-ifi-pred ;; identified group, only one IFI
                  :else (s/pred (fn [{:strs [member]}]
                                  (not (nil? member))) :predicates/no-anon-group-member)))
 
+;; TODO: remove
 (def InteractionComponentsValidations
   (s/pred unique-ids? :predicates/distinct-ic-ids))
 
+;; TODO: remove
 (def DefinitionValidations
   (s/pred valid-component-keys? :predicates/valid-component-keys))
 
-
+;; TODO: remove
 (def ScoreValidations
   (s/both (s/pred (fn
                     [x]

--- a/src/xapi_schema/schemata/util.cljc
+++ b/src/xapi_schema/schemata/util.cljc
@@ -90,7 +90,7 @@
          (str (t ltag :in) " " in ": " value)
 
          [(['present? required] :seq)]
-         (str (t ltag :present) ": " required)
+         (str (t ltag :present) ": " (t ltag required))
 
          ;; predicate with string message
          [([(pred-msg :guard string?) value] :seq)]


### PR DESCRIPTION
Gets rid of deprecation warnings for the use of `schema.core/both`