### PR TITLE
61 bug score unform

### DIFF
--- a/src/xapi_schema/spec.cljc
+++ b/src/xapi_schema/spec.cljc
@@ -34,7 +34,9 @@
                  (try (double n)
                       (catch #?(:clj Exception
                                 :cljs js/Error) e
-                        ::s/invalid)))))
+                        ::s/invalid)))
+               ;; unform is a no-op, as json doesn't care
+               identity))
 
 (defn conform-ns-map [map-ns string-map]
   (if (map? string-map)
@@ -114,7 +116,7 @@
             ::language-map-text
             :gen-max 3
             :min-count 1))
-            
+
 
 (defn into-str [cs]
   (cstr/lower-case (apply str cs)))
@@ -227,7 +229,7 @@
                              (sgen/vector (sgen/char-alpha) 3 4))
                   (sgen/fmap into-str
                              (sgen/vector (sgen/char-alpha) 3 16))))))
-                  
+
 
 (s/def ::uuid
   (s/with-gen

--- a/test/xapi_schema/spec_test.cljc
+++ b/test/xapi_schema/spec_test.cljc
@@ -13,7 +13,7 @@
   (is (= long-statement (s/unform ::xs/statement (s/conform ::xs/statement long-statement)))))
 
 (deftest conform-ns-map-test
-  (is  (= (name (xs/conform-ns-map "foo/bar" [])) 
+  (is  (= (name (xs/conform-ns-map "foo/bar" []))
           "invalid")))
 
 (deftest language-tag-test
@@ -81,7 +81,7 @@
                      :bad
                      "09-10-2014T14:12:00+500"
                      "2014-09-12T03:47:40"))) ;; no time zone
-                     
+
 
 (deftest duration-test
   (testing "is a valid ISO 8601 Duration"
@@ -93,7 +93,7 @@
                      "P"
                      "PT"
                      "P3Y6M4DT12H30.1M5S"))) ;; bad fractional
-                     
+
 
 (deftest version-test
   (testing "is a valid xAPI 1.0.X version"
@@ -299,7 +299,12 @@
                       "min" 99
                       "max" 1}))
   (testing "can be empty"
-    (should-satisfy :result/score {})))
+    (should-satisfy :result/score {}))
+  (testing "can be conformed/unformed, per https://github.com/yetanalytics/xapi-schema/issues/61"
+    (is (= {"scaled" 0.5}
+           (->> {"scaled" 0.5}
+                (s/conform :result/score)
+                (s/unform :result/score))))))
 
 (deftest result-test
   (testing "can be empty"

--- a/test/xapi_schema/spec_test.cljc
+++ b/test/xapi_schema/spec_test.cljc
@@ -9,6 +9,16 @@
             [xapi-schema.support.data :as d :refer [simple-statement
                                                     long-statement]]))
 
+(deftest double-conformer-test
+  (testing "conforms to double"
+    (is (= 1.0
+           (s/conform xs/double-conformer 1))))
+  (testing "unform is a no-op"
+    (is (= 1.0
+           (->> 1
+                (s/conform xs/double-conformer)
+                (s/unform xs/double-conformer))))))
+
 (deftest conform-unform-test
   (is (= long-statement (s/unform ::xs/statement (s/conform ::xs/statement long-statement)))))
 


### PR DESCRIPTION
This PR fixes the bug found in #61, where conforming and then unforming a statement:result:score would throw an error. There was a missing `unform` function in `xapi-schema.spec/double-conformer` which was causing the problem.

The solution was to make the `unform` function a no-op, `clojure.core/identity`, as JSON only has the one number type.