### PR TITLE
Remove deprecation warning

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,4 +12,4 @@
     com.walmartlabs/lacinia
     {:mvn/version "0.25.0"
      :exclusions [org.clojure/clojure
-                  clojure-future-spec]}}}}}
+                  clojure-future-spec/clojure-future-spec]}}}}}


### PR DESCRIPTION
Changed `clojure-future-spec` to `clojure-future-spec/clojure-future-spec` in deps.edn, in order to remove deprecation warning (which has been annoying me since xapi-schema is in the dep tree for all my projects).