### PR TITLE
Correct attachment SHA2 spec

### DIFF
--- a/README.org
+++ b/README.org
@@ -150,7 +150,7 @@ xapi_schema.core.validate_statement_data_js(statement_json); // => statement JSO
 
 ** License
 
-Copyright © 2018 Yet Analytics, Inc.
+Copyright © 2021 Yet Analytics, Inc.
 
 Distributed under the Eclipse Public License, the same as Clojure.
 See the file [[file:LICENSE][LICENSE]] for details.

--- a/src/xapi_schema/spec.cljc
+++ b/src/xapi_schema/spec.cljc
@@ -9,17 +9,15 @@
                                    TimestampRegEx
                                    xAPIVersionRegEx
                                    DurationRegEx
-                                   Base64RegEx
-                                   Sha1RegEx]]
+                                   Sha1RegEx
+                                   Sha2RegEx]]
    [clojure.spec.alpha :as s #?@(:cljs [:include-macros true])]
    [clojure.spec.gen.alpha :as sgen :include-macros true]
    [clojure.string :as cstr]
    #?@(:cljs [[goog.string :as gstring]
               [goog.string.format]
-              [goog.crypt]
-              [goog.crypt.base64 :as base64]]))
-  #?(:clj (:import [java.util Base64])
-     :cljs (:require-macros [xapi-schema.spec :refer [conform-ns]])))
+              [goog.crypt]]))
+  #?(:cljs (:require-macros [xapi-schema.spec :refer [conform-ns]])))
 
 (def ^:dynamic *xapi-0-95-compat?*
   "When true, coerce 0.95 context activities to conform."
@@ -296,14 +294,14 @@
 (s/def ::sha2
   (s/with-gen
     (s/and string?
-           (partial re-matches Base64RegEx))
-    #(sgen/fmap
-      (fn [^String s]
-        #?(:clj (String. (.encode
-                          (Base64/getEncoder)
-                          (.getBytes s)))
-           :cljs (base64/encodeString s)))
-      (sgen/not-empty (sgen/string-alphanumeric)))))
+           (partial re-matches Sha2RegEx))
+   #(sgen/fmap
+     (fn [is]
+       (apply str (map char is)))
+     (sgen/vector (sgen/elements (concat
+                                  (range 65 71)
+                                  (range 48 58)))
+                  64))))
 
 (s/def ::sha1sum
   (s/with-gen
@@ -317,7 +315,7 @@
       (sgen/vector (sgen/elements (concat
                                    (range 65 71)
                                    (range 48 58)))
-                40))))
+                   40))))
 
 ;; Activity Definition
 
@@ -993,6 +991,10 @@
 
 (s/def :attachment/fileUrl
   ::irl)
+
+;; Note: The SHA2 hash may not correspond to any attachment with the given
+;; length and content type. This spec is okay for pure validation, but for
+;; generation a more sophisticated algorithm is recommended.
 
 (s/def ::file-attachment
   (conform-ns "attachment"

--- a/src/xapi_schema/spec.cljc
+++ b/src/xapi_schema/spec.cljc
@@ -15,8 +15,7 @@
    [clojure.spec.gen.alpha :as sgen :include-macros true]
    [clojure.string :as cstr]
    #?@(:cljs [[goog.string :as gstring]
-              [goog.string.format]
-              [goog.crypt]]))
+              [goog.string.format]]))
   #?(:cljs (:require-macros [xapi-schema.spec :refer [conform-ns]])))
 
 (def ^:dynamic *xapi-0-95-compat?*

--- a/src/xapi_schema/spec/regex.cljc
+++ b/src/xapi_schema/spec/regex.cljc
@@ -163,3 +163,6 @@
 
 (def Sha1RegEx
   #"^[0-9a-fA-F]{40}$")
+
+(def Sha2RegEx
+  #"^[0-9a-fA-F]{64}$")

--- a/test/xapi_schema/spec/regex_test.cljc
+++ b/test/xapi_schema/spec/regex_test.cljc
@@ -13,6 +13,7 @@
                                    DurationRegEx
                                    Base64RegEx
                                    Sha1RegEx
+                                   Sha2RegEx
                                    OpenIdRegEx]]))
 
 (deftest language-tag-regex-test
@@ -175,3 +176,8 @@
   (testing "matches SHA-1 hashes"
     (is (re-matches Sha1RegEx "ebd31e95054c018b10727ccffd2ef2ec3a016ee9"))
     (is (not (re-matches Sha1RegEx "1234")))))
+
+(deftest sha2-regex-test
+  (testing "matches SHA-2 hashes"
+    (is (re-matches Sha2RegEx "495395e777cd98da653df9615d09c0fd6bb2f8d4788394cd53c56a3bfdcd848a"))
+    (is (not (re-matches Sha2RegEx "Q3lxN0R1NQ==")))))

--- a/test/xapi_schema/spec_test.cljc
+++ b/test/xapi_schema/spec_test.cljc
@@ -151,7 +151,8 @@
     (should-satisfy+ ::xs/sha2
                      "672fa5fa658017f1b72d65036f13379c6ab05d4ab3b6664908d8acf0b6a0c634"
                      :bad
-                     123)))
+                     123
+                     "Q3lxN0R1NQ==")))
 
 (deftest sha1sum-test
   (testing "is a SHA-1 string of 40 hex chars"


### PR DESCRIPTION
Before, the attachment SHA2 spec used the Base64 regex, which was wrong. This PR corrects the spec to use the actual SHA2 regex (i.e. a length-64 hexadecimal string).