### PR TITLE
Allow v5-8 uuids

### DIFF
--- a/src/xapi_schema/spec/regex.cljc
+++ b/src/xapi_schema/spec/regex.cljc
@@ -100,7 +100,7 @@
 (def UuidRegEx ; RFC 3984
   (re-pattern (str "[0-9A-Fa-f]{8}-" ; [0-9A-Fa-f] = hex digit
                    "[0-9A-Fa-f]{4}-"
-                   "[0-8][0-9A-Fa-f]{3}-"
+                   "[1-8][0-9A-Fa-f]{3}-"
                    "[0-9A-Fa-f]{4}-"
                    "[0-9A-Fa-f]{12}")))
 

--- a/src/xapi_schema/spec/regex.cljc
+++ b/src/xapi_schema/spec/regex.cljc
@@ -100,7 +100,7 @@
 (def UuidRegEx ; RFC 3984
   (re-pattern (str "[0-9A-Fa-f]{8}-" ; [0-9A-Fa-f] = hex digit
                    "[0-9A-Fa-f]{4}-"
-                   "[1-8][0-9A-Fa-f]{3}-"
+                   "[0-8][0-9A-Fa-f]{3}-"
                    "[0-9A-Fa-f]{4}-"
                    "[0-9A-Fa-f]{12}")))
 

--- a/src/xapi_schema/spec/regex.cljc
+++ b/src/xapi_schema/spec/regex.cljc
@@ -1,7 +1,7 @@
 (ns xapi-schema.spec.regex
   (:require [clojure.string :refer [join]]))
 
-(def LanguageTagRegEx ; RFC 5646, w/ lang subtag limitation 
+(def LanguageTagRegEx ; RFC 5646, w/ lang subtag limitation
   (let [;; Language Subtags
         ;; Note: we exclude 4-8 char subtags, even though they are allowed in
         ;; the RFC spec, since they are reserved for future (not current) use.
@@ -100,7 +100,7 @@
 (def UuidRegEx ; RFC 3984
   (re-pattern (str "[0-9A-Fa-f]{8}-" ; [0-9A-Fa-f] = hex digit
                    "[0-9A-Fa-f]{4}-"
-                   "[1-4][0-9A-Fa-f]{3}-"
+                   "[1-8][0-9A-Fa-f]{3}-"
                    "[0-9A-Fa-f]{4}-"
                    "[0-9A-Fa-f]{12}")))
 

--- a/test/xapi_schema/spec/regex_test.cljc
+++ b/test/xapi_schema/spec/regex_test.cljc
@@ -125,6 +125,7 @@
     (is (not (re-matches UuidRegEx "3c7db14d-ac4b-4e35-b2c6-3b2237f382")))
     (is (not (re-matches UuidRegEx "MA97B177-9383-4934-8543-0F91A7A02836"))))
   (testing "matches all UUID versions"
+    (is (re-matches UuidRegEx "f47ac10b-58cc-0372-0567-0e02b2c3d479"))
     (is (re-matches UuidRegEx "f47ac10b-58cc-1372-0567-0e02b2c3d479"))
     (is (re-matches UuidRegEx "f47ac10b-58cc-2372-0567-0e02b2c3d479"))
     (is (re-matches UuidRegEx "f47ac10b-58cc-3372-0567-0e02b2c3d479"))

--- a/test/xapi_schema/spec/regex_test.cljc
+++ b/test/xapi_schema/spec/regex_test.cljc
@@ -128,7 +128,11 @@
     (is (re-matches UuidRegEx "f47ac10b-58cc-1372-0567-0e02b2c3d479"))
     (is (re-matches UuidRegEx "f47ac10b-58cc-2372-0567-0e02b2c3d479"))
     (is (re-matches UuidRegEx "f47ac10b-58cc-3372-0567-0e02b2c3d479"))
-    (is (re-matches UuidRegEx "f47ac10b-58cc-4372-0567-0e02b2c3d479"))))
+    (is (re-matches UuidRegEx "f47ac10b-58cc-4372-0567-0e02b2c3d479"))
+    (is (re-matches UuidRegEx "f47ac10b-58cc-5372-0567-0e02b2c3d479"))
+    (is (re-matches UuidRegEx "f47ac10b-58cc-6372-0567-0e02b2c3d479"))
+    (is (re-matches UuidRegEx "f47ac10b-58cc-7372-0567-0e02b2c3d479"))
+    (is (re-matches UuidRegEx "f47ac10b-58cc-8372-0567-0e02b2c3d479"))))
 
 (deftest timestamp-regex-test
   (testing "matches valid ISO 8601 datetime stamps within the rfc3339 profile"

--- a/test/xapi_schema/spec/regex_test.cljc
+++ b/test/xapi_schema/spec/regex_test.cljc
@@ -125,7 +125,6 @@
     (is (not (re-matches UuidRegEx "3c7db14d-ac4b-4e35-b2c6-3b2237f382")))
     (is (not (re-matches UuidRegEx "MA97B177-9383-4934-8543-0F91A7A02836"))))
   (testing "matches all UUID versions"
-    (is (re-matches UuidRegEx "f47ac10b-58cc-0372-0567-0e02b2c3d479"))
     (is (re-matches UuidRegEx "f47ac10b-58cc-1372-0567-0e02b2c3d479"))
     (is (re-matches UuidRegEx "f47ac10b-58cc-2372-0567-0e02b2c3d479"))
     (is (re-matches UuidRegEx "f47ac10b-58cc-3372-0567-0e02b2c3d479"))

--- a/test/xapi_schema/spec_test.cljc
+++ b/test/xapi_schema/spec_test.cljc
@@ -84,8 +84,9 @@
                      "some other crap")))
 
 (deftest uuid-test
-  (testing "is a valid v1-8 UUID"
+  (testing "is a valid v0-8 UUID"
     (should-satisfy+ ::xs/uuid
+                     "00000000-0000-0000-0000-000000000000"
                      "f47ac10b-58cc-4372-a567-0e02b2c3d479"
                      "12345678-1234-1234-1234-123456789012"
                      "017b4f9f-2a7e-84f1-80e9-7b788a5baba4"

--- a/test/xapi_schema/spec_test.cljc
+++ b/test/xapi_schema/spec_test.cljc
@@ -84,13 +84,14 @@
                      "some other crap")))
 
 (deftest uuid-test
-  (testing "is a valid v4 UUID"
+  (testing "is a valid v1-8 UUID"
     (should-satisfy+ ::xs/uuid
                      "f47ac10b-58cc-4372-a567-0e02b2c3d479"
                      "12345678-1234-1234-1234-123456789012"
+                     "017b4f9f-2a7e-84f1-80e9-7b788a5baba4"
                      :bad
-                     ;; 6 is not a valid version number
-                     "12345678-1234-6234-1234-123456789012")))
+                     ;; 9 is not a valid version number
+                     "12345678-1234-9234-1234-123456789012")))
 
 (deftest timestamp-test
   (testing "is a valid ISO 8601 DateTime"

--- a/test/xapi_schema/spec_test.cljc
+++ b/test/xapi_schema/spec_test.cljc
@@ -84,9 +84,8 @@
                      "some other crap")))
 
 (deftest uuid-test
-  (testing "is a valid v0-8 UUID"
+  (testing "is a valid v1-8 UUID"
     (should-satisfy+ ::xs/uuid
-                     "00000000-0000-0000-0000-000000000000"
                      "f47ac10b-58cc-4372-a567-0e02b2c3d479"
                      "12345678-1234-1234-1234-123456789012"
                      "017b4f9f-2a7e-84f1-80e9-7b788a5baba4"


### PR DESCRIPTION
With the release of v6-8, and the occasional presence of v5 named uuids, we'll allow through 8.