### PR TITLE
Fix `:result/score` generator.

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,7 +2,7 @@
 #+AUTHOR: Milt Reder
 #+EMAIL: milt@yetanalytics.com
 
-[[https://github.com/yetanalytics/xapi-schema/actions/workflows/main.yml][https://github.com/yetanalytics/xapi-schema/actions/workflows/main.yml/badge.svg]]
+[[https://travis-ci.org/yetanalytics/xapi-schema][https://travis-ci.org/yetanalytics/xapi-schema.svg?branch=master]]
 [[https://jarkeeper.com/yetanalytics/xapi-schema][https://jarkeeper.com/yetanalytics/xapi-schema/status.png]]
 [[https://www.eclipse.org/legal/epl-v10.html][https://img.shields.io/badge/license-Eclipse-blue.svg]]
 [[https://clojars.org/com.yetanalytics/xapi-schema][https://img.shields.io/clojars/v/com.yetanalytics/xapi-schema.svg]]


### PR DESCRIPTION
When running CI on downstream libs, the following anomalous error sometimes appears:

```
#error {:message "Couldn't satisfy such-that predicate after 10 tries.", :data {:pred #object[xapi_schema$spec$valid_min_max_raw_QMARK_], :gen #clojure.test.check.generators.Generator{:gen #object[Function]}, :max-tries 10}}
```

To fix this, I updated the `:result/score` generator in order to use a coercion function with `fmap`, rather than a filter function with `such-that`. The coercion function reorders the `:score/raw`, `:score/min`, and `:score/max` keys if they are out of order.