### PR TITLE
LRS-82 Allow empty contextActivities map

### DIFF
--- a/src/xapi_schema/spec.cljc
+++ b/src/xapi_schema/spec.cljc
@@ -944,10 +944,10 @@
 (s/def :context/contextActivities
   (conform-ns "contextActivities"
               (s/and
-               (s/keys :req [(or :contextActivities/parent
-                                 :contextActivities/grouping
-                                 :contextActivities/category
-                                 :contextActivities/other)])
+               (s/keys :opt [:contextActivities/parent
+                             :contextActivities/grouping
+                             :contextActivities/category
+                             :contextActivities/other])
                (restrict-keys :contextActivities/parent
                               :contextActivities/grouping
                               :contextActivities/category

--- a/test/xapi_schema/spec_test.cljc
+++ b/test/xapi_schema/spec_test.cljc
@@ -376,8 +376,8 @@
                      ["foo"])))
 
 (deftest context-activities-map-test
-  (testing "cannot be empty"
-    (should-not-satisfy ::xs/context-activities {})))
+  (testing "can be empty"
+    (should-satisfy :context/contextActivities {})))
 
 (deftest context-test
   (testing "can be empty"


### PR DESCRIPTION
[LRS-82] Allow contextActivities to be an empty map.
previously the test was pointed at the array which was wrong

[LRS-82]: https://yet.atlassian.net/browse/LRS-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ