### PR TITLE
resolved raw string cljs statement-data bug

### DIFF
--- a/src/xapi_schema/core.cljc
+++ b/src/xapi_schema/core.cljc
@@ -39,7 +39,7 @@
                                       :else sd))
      :cljs (validate-statement-data*
             (cond
-              (string? sd) (.parse js/JSON sd)
+              (string? sd) (js->clj (.parse js/JSON sd))
               :else sd))))
 
 #?(:cljs

--- a/test/xapi_schema/core_test.cljc
+++ b/test/xapi_schema/core_test.cljc
@@ -8,7 +8,6 @@
                              validate-statements
                              validate-statement-data
                              #?(:cljs validate-statement-data-js)]]
-   [clojure.pprint :refer [pprint]]
    #?(:clj [clojure.data.json :as json]
       :cljs [cljs.core :refer [ExceptionInfo]]))
   #?(:clj (:import [clojure.lang ExceptionInfo])))

--- a/test/xapi_schema/core_test.cljc
+++ b/test/xapi_schema/core_test.cljc
@@ -8,6 +8,7 @@
                              validate-statements
                              validate-statement-data
                              #?(:cljs validate-statement-data-js)]]
+   [clojure.pprint :refer [pprint]]
    #?(:clj [clojure.data.json :as json]
       :cljs [cljs.core :refer [ExceptionInfo]]))
   #?(:clj (:import [clojure.lang ExceptionInfo])))
@@ -73,7 +74,13 @@
      (testing "with string data"
        (let [statement (json/write-str long-statement)]
          (testing "it parses and returns the validated data"
-           (is (= long-statement (validate-statement-data statement)))))))
+           (is (= long-statement (validate-statement-data statement)))))) 
+     :cljs
+     (testing "with string data"
+       (let [json     (clj->js long-statement)
+             json-str (.stringify js/JSON json)]
+         (testing "it parses and returns the validated data"
+           (is (= long-statement (validate-statement-data json-str))))))) 
 
   #?(:cljs
      (testing "with nested data"


### PR DESCRIPTION
String inputs in cljs were kind of in a testing loophole. CLJ tested raw strings and cljs tested JS objects, but actually a conversion step was missing for cljs for raws.