### PR TITLE
Empty language maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@
 /resources/public/xapi_schema.js
 .specljs-timestamp
 /.cpcache
+/.calva
 /.clj-kondo
 /.lsp

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 /resources/public/xapi_schema.js
 .specljs-timestamp
 /.cpcache
+/.clj-kondo
+/.lsp

--- a/README.org
+++ b/README.org
@@ -15,7 +15,7 @@ You can use xapi-schema to validate (and generate) statements in real-time [[htt
 ** Getting Started
 1. Add to your project dependencies:
   #+BEGIN_SRC clojure
-  [[com.yetanalytics/xapi-schema "1.2.1"]]
+  [[com.yetanalytics/xapi-schema "1.3.0"]]
   #+END_SRC
 2. Require in your project:
   #+BEGIN_SRC clojure

--- a/src/xapi_schema/spec.cljc
+++ b/src/xapi_schema/spec.cljc
@@ -106,11 +106,7 @@
 (s/def ::language-map
   (s/map-of ::language-tag
             ::language-map-text
-            :gen-max 3
-            ;; Technically, empty language maps are allowed under the xAPI spec.
-            ;; However, they are nonsensical in most contexts and will not
-            ;; work in downstream libs (e.g those that use DynamoDB).
-            :min-count 1))
+            :gen-max 3))
 
 
 (defn into-str [cs]

--- a/test/xapi_schema/spec_test.cljc
+++ b/test/xapi_schema/spec_test.cljc
@@ -40,12 +40,10 @@
                      {"en-US" "foo"}
                      {"es" "hola mundo"}
                      {"zh-cmn" "你好世界"}
+                     {} ; empty lang maps are allowed by spec
                      :bad
                      {"hey there" "foo"}
-                     {"en" 2}
-                     ;; We do not allow for empty maps (despite technically
-                     ;; being spec-conformant)
-                     {})))
+                     {"en" 2})))
 
 (deftest iri-test
   (testing "must be a valid url with scheme"


### PR DESCRIPTION
Empty language maps are technically allowed by the xAPI spec, but we have refrained from allowing them in order to avoid breaking downstream apps. However, with the deprecation of some of these downstream apps and the requirement to support empty lang maps in others, it is time to update the spec.