### PR TITLE
[LRS-83] Allow empty statement batches

### DIFF
--- a/src/xapi_schema/spec.cljc
+++ b/src/xapi_schema/spec.cljc
@@ -1326,8 +1326,13 @@
                    (some-> s :statement/object :statement-ref/objectType)
                    true)))))
 
+;; Statement batches in general, e.g. when being inserted into an LRS, should
+;; allow empty arrays.
+
+;; Statement batches being retrieved from an LRS should always be non-emtpy.
+
 (s/def ::statements
-  (s/coll-of ::statement :into [] :min-count 1))
+  (s/coll-of ::statement :into []))
 
 (s/def ::lrs-statements
   (s/coll-of ::lrs-statement :into [] :min-count 1))

--- a/src/xapi_schema/spec.cljc
+++ b/src/xapi_schema/spec.cljc
@@ -1326,13 +1326,8 @@
                    (some-> s :statement/object :statement-ref/objectType)
                    true)))))
 
-;; Statement batches in general, e.g. when being inserted into an LRS, should
-;; allow empty arrays.
-
-;; Statement batches being retrieved from an LRS should always be non-emtpy.
-
 (s/def ::statements
   (s/coll-of ::statement :into []))
 
 (s/def ::lrs-statements
-  (s/coll-of ::lrs-statement :into [] :min-count 1))
+  (s/coll-of ::lrs-statement :into []))

--- a/test/xapi_schema/spec_test.cljc
+++ b/test/xapi_schema/spec_test.cljc
@@ -636,5 +636,4 @@
   (testing "LRS retrieval statement batch"
     (should-satisfy+ ::xs/lrs-statements
                      [d/statement] ; This statement has ID and other required fields
-                     :bad
                      [])))

--- a/test/xapi_schema/spec_test.cljc
+++ b/test/xapi_schema/spec_test.cljc
@@ -626,3 +626,16 @@
                       "verb" {"id" "http://adlnet.gov/expapi/verbs/voided"
                               "display" {"en-US" "voided"}}
                       "object" {"id" "http://example.com/activities/1"}})))
+
+(deftest statements-test
+  (testing "generic statememt batch"
+    (should-satisfy+ ::xs/statements
+                     [simple-statement]
+                     [simple-statement long-statement]
+                     []))
+  (testing "LRS retrieval statement batch"
+    (should-satisfy+ ::xs/lrs-statements
+                     [simple-statement]
+                     [simple-statement long-statement]
+                     :bad
+                     [])))

--- a/test/xapi_schema/spec_test.cljc
+++ b/test/xapi_schema/spec_test.cljc
@@ -635,7 +635,6 @@
                      []))
   (testing "LRS retrieval statement batch"
     (should-satisfy+ ::xs/lrs-statements
-                     [simple-statement]
-                     [simple-statement long-statement]
+                     [d/statement] ; This statement has ID and other required fields
                      :bad
                      [])))


### PR DESCRIPTION
Empty statement batches are allowed by the xAPI spec for LRSs (and most other purposes), so this update allows them in the spec.

NOTE: This is a breaking change, as this will affect the behavior of LRSs with regards to POSTing and GETing empty statement batches.